### PR TITLE
Change &Vec<T> → &[T]

### DIFF
--- a/bestpath/src/lib.rs
+++ b/bestpath/src/lib.rs
@@ -48,7 +48,7 @@ fn min_distance_heuristic(p1: Position, p2: Position) -> usize {
 
 /// Return the navigable neighbouring cells to the given one.
 #[inline]
-fn neighbours(grid: &Vec<Vec<char>>, pos: Position) -> Vec<Position> {
+fn neighbours(grid: &[Vec<char>], pos: Position) -> Vec<Position> {
     let mut v = Vec::new();
 
     if pos.x > 0 && grid[pos.y][pos.x-1] == ' ' {
@@ -109,7 +109,7 @@ fn reconstruct(came_from: &HashMap<Position, Position>,
 ///            find_path(&grid, Position{x: 0, y: 0}, Position{x: 3, y: 0}));
 /// ```
 #[inline]
-pub fn find_path(grid: &Vec<Vec<char>>, start: Position, goal: Position) 
+pub fn find_path(grid: &[Vec<char>], start: Position, goal: Position)
         -> Option<Vec<Position>>  {
     let mut frontier = BinaryHeap::new();
     frontier.push(PositionPriority { minimum_cost: 0, position: start });
@@ -166,9 +166,9 @@ pub fn find_path(grid: &Vec<Vec<char>>, start: Position, goal: Position)
 ///            format_path_map(&grid, &path));
 /// ```
 #[inline]
-pub fn format_path_map(grid: &Vec<Vec<char>>, path: &Vec<Position>)
+pub fn format_path_map(grid: &[Vec<char>], path: &[Position])
         -> Vec<Vec<char>> {
-    let mut m = grid.clone();
+    let mut m = grid.to_vec();
     let last_path = path.len() - 1;
     for (i, p) in path.iter().enumerate() {
         m[p.y][p.x] = match i {
@@ -181,7 +181,7 @@ pub fn format_path_map(grid: &Vec<Vec<char>>, path: &Vec<Position>)
 }
 
 #[cfg(test)]
-fn print_grid(grid: &Vec<Vec<char>>) {
+fn print_grid(grid: &[Vec<char>]) {
     println!("");
     for row in grid {
         for ch in row {

--- a/i18n/prefix/src/main.rs
+++ b/i18n/prefix/src/main.rs
@@ -74,7 +74,7 @@ fn insert_in_trie(word : &str, node: &mut Node) {
 }
 
 /// Map each word length to a set of tries containing only words of that length.
-fn build_length_to_trie_map(words: &Vec<String>) -> HashMap<usize, Node> {
+fn build_length_to_trie_map(words: &[String]) -> HashMap<usize, Node> {
     let mut length_to_trie = HashMap::new();
 
     for word in words {

--- a/i18n/sets/src/main.rs
+++ b/i18n/sets/src/main.rs
@@ -54,7 +54,7 @@ fn load_dictionary(dictionary_path: &Path) -> Vec<String> {
 /// For example:
 ///   1 => ["a", "I", etc.]
 ///   3 => ["art", "can", con", "mat", etc.]
-fn build_maps(words: &Vec<String>) -> (
+fn build_maps(words: &[String]) -> (
         HashMap<(char, usize, usize), HashSet<&str>>,
         HashMap<usize, Vec<&str>>) {
     let mut ch_position_length_map :

--- a/pancake/src/lib.rs
+++ b/pancake/src/lib.rs
@@ -1,13 +1,13 @@
 /// Reverse the items in the list from [0..index].
 #[inline]
-fn reverse_until_index<T>(v: &mut Vec<T>, index: usize) {
+fn reverse_until_index<T>(v: &mut [T], index: usize) {
     let (mut first, _) = v.split_at_mut(index+1);
     first.reverse();
 }
 
 /// Return the index of the largest item in the Vec between [0..index].
 #[inline]
-fn index_of_max<T>(v: &Vec<T>, index: usize) -> usize where T: PartialOrd {
+fn index_of_max<T>(v: &[T], index: usize) -> usize where T: PartialOrd {
     let mut max = &v[0];
     let mut max_index = 0;
     for i in 0..(index+1) {
@@ -32,7 +32,7 @@ fn index_of_max<T>(v: &Vec<T>, index: usize) -> usize where T: PartialOrd {
 /// assert_eq!(vec![1, 1, 2, 3, 4, 5, 7, 8, 9], v);
 /// ```
 #[inline]
-pub fn pancake_sort<T>(v: &mut Vec<T>) where T: PartialOrd {
+pub fn pancake_sort<T>(v: &mut [T]) where T: PartialOrd {
     if v.len() == 0 {
         return;
     }

--- a/reversewords/src/lib.rs
+++ b/reversewords/src/lib.rs
@@ -5,7 +5,7 @@ const SPACE: u8 = 0x20;
 /// Reverse the contents of the input vector between `from` and `to`
 /// inclusively.
 #[inline]
-fn reverse_vec(v: &mut Vec<u8>, from: usize, to: usize) {
+fn reverse_vec(v: &mut [u8], from: usize, to: usize) {
     let mut left = from;
     let mut right = to;
     while left < right {

--- a/targetsum/src/lib.rs
+++ b/targetsum/src/lib.rs
@@ -9,13 +9,13 @@
 /// assert_eq!(Some((3, 7)), target_sum(&vec![1, 2, 3, 5, 7, 11, 13], 10));
 /// assert_eq!(None, target_sum(&vec![1, 2, 3, 5, 7, 11, 13], 11));
 /// ```
-pub fn target_sum(search: &Vec<i32>, target: i32) -> Option<(i32, i32)> {
+pub fn target_sum(search: &[i32], target: i32) -> Option<(i32, i32)> {
     if search.len() == 0 {
         return None;
     }
     // For some reason hash tables are not allowed so sort the vector and
     // search from the ends.
-    let mut sorted_search = search.clone();
+    let mut sorted_search = search.to_vec();
     sorted_search.sort();
     let mut lowest_index = 0;
     let mut highest_index = sorted_search.len() - 1;


### PR DESCRIPTION
Functions should always prefer `&[T]` over `&Vec<T>`, because it is more
general. This requires no changes to call sites, because `&Vec<T>` coerces
to `&[T]`.
